### PR TITLE
request reset to bootloader mode in Windows

### DIFF
--- a/win/stm32CubeProg.bat
+++ b/win/stm32CubeProg.bat
@@ -59,8 +59,13 @@ set PORT=%~3
 shift
 goto :opt
 
+:: Finds the COMPORT with manufacturer StMicro and knocks the COM POrt at 1200 baud rate
 :DFU
 set PORT=USB1
+wmic path Win32_SerialPort Where "Caption LIKE '%%StMicro%%'" Get DeviceID | findstr "COM" > tmpFile.txt
+del tmpFile.txt 
+set /p cdc_port=<tmpFile.txt
+mode %%cdc_port%% BAUD=1200
 goto :opt
 
 :opt


### PR DESCRIPTION
Add support to request reset to bootloader mode  for windows
This will auto-detect the available Stm32 virtual comport and knocks the com port at 1200 bauds and the controller jumps to the internal USB DFU method.
I have tested this on Windows 10 for my [stm32f411-disco](https://www.st.com/en/evaluation-tools/32f411ediscovery.html) board using this  
[PR](https://github.com/stm32duino/Arduino_Core_STM32/pull/710)